### PR TITLE
fixing 3.12 and above compatibility - no imp module

### DIFF
--- a/j2gpp/j2gpp.py
+++ b/j2gpp/j2gpp.py
@@ -15,7 +15,6 @@
 
 import argparse
 import glob
-import imp
 import os
 import re
 import errno
@@ -28,10 +27,22 @@ import jinja2.exceptions as jinja2_exceptions
 from j2gpp.utils import *
 from j2gpp.filters import extra_filters, write_source_toggle
 from j2gpp.tests import extra_tests
+import importlib.util
+import importlib.machinery
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 def main():
 
-  j2gpp_version = "2.2.1"
+  j2gpp_version = "2.2.2"
 
   # Source templates
   sources = []
@@ -457,7 +468,7 @@ def main():
     filters = {}
     for filter_path in filter_paths:
       if os.path.isfile(filter_path):
-        filter_module = imp.load_source("", filter_path)
+        filter_module = load_source("", filter_path)
         for filter_name in dir(filter_module):
           if filter_name[0] != '_':
             print(f"Loading filter '{filter_name}' from '{filter_path}'.")
@@ -472,7 +483,7 @@ def main():
     tests = {}
     for test_path in test_paths:
       if os.path.isfile(test_path):
-        test_module = imp.load_source("", test_path)
+        test_module = load_source("", test_path)
         for test_name in dir(test_module):
           if test_name[0] != '_':
             test_function = getattr(test_module, test_name)
@@ -489,7 +500,7 @@ def main():
     file_vars_adapter_name = file_vars_adapter[1]
     print(f"Loading variables file adapter function '{file_vars_adapter_name}' from '{file_vars_adapter_path}'.")
     try:
-      file_vars_adapter_module = imp.load_source("", file_vars_adapter_path)
+      file_vars_adapter_module = load_source("", file_vars_adapter_path)
       file_vars_adapter_function = getattr(file_vars_adapter_module, file_vars_adapter_name)
       if not callable(file_vars_adapter_function):
         throw_error(f"Object '{file_vars_adapter_name}' from '{file_vars_adapter_path}' is not a function.")
@@ -508,7 +519,7 @@ def main():
     global_vars_adapter_name = global_vars_adapter[1]
     print(f"Loading global variables adapter function '{global_vars_adapter_name}' from '{global_vars_adapter_path}'.")
     try:
-      global_vars_adapter_module = imp.load_source("", global_vars_adapter_path)
+      global_vars_adapter_module = load_source("", global_vars_adapter_path)
       global_vars_adapter_function = getattr(global_vars_adapter_module, global_vars_adapter_name)
       if not callable(global_vars_adapter_function):
         throw_error(f"Object '{global_vars_adapter_name}' from '{global_vars_adapter_path}' is not a function.")

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 from setuptools import setup, find_packages
 
 setup(name         = 'j2gpp',
-      version      = '2.2.1',
+      version      = '2.2.2',
       description  = 'A Jinja2-based General Purpose Preprocessor',
       keywords     = ['j2gpp', 'jinja2', 'preprocessor'],
       url          = 'https://github.com/Louis-DR/j2gpp',


### PR DESCRIPTION
This is a simple fix due to recent deprecation of imp module.
See also here: https://docs.python.org/3.12/whatsnew/3.12.html#whatsnew312-removed-imp